### PR TITLE
remove auto refilling for account form

### DIFF
--- a/src/stores/mainStore.js
+++ b/src/stores/mainStore.js
@@ -23,7 +23,7 @@ export default function mainStore(initialState) {
   store.subscribe(() => {
     saveState({
       // allows saving to local storage of passwords from forms; up to the page to hose passwords before route changes
-      accountForm: store.getState().accountForm,
+      // accountForm: store.getState().accountForm,
       deviceForm: store.getState().deviceForm,
       servicesForm: store.getState().servicesForm,
     });


### PR DESCRIPTION
Concerns #39

This change removes setting the account form's fields from the redux store. I can not change it for the browser. This should also fix the incorrect password filling. Please double check this on your side @linggao or @bmpotter 