### PR TITLE
remove computed metering attributes for location service and add chec…

### DIFF
--- a/src/actions/servicesRequests.js
+++ b/src/actions/servicesRequests.js
@@ -73,7 +73,6 @@ export function locationService(usegps, metered = false, ram) {
         }
       },
       {...computeAttrs('Device location', ram)},
-      {...meteringAttrs(metered)},
     ]
   };
 

--- a/src/components/Dashboard/presenter.js
+++ b/src/components/Dashboard/presenter.js
@@ -266,7 +266,7 @@ class Dashboard extends Component {
                         <span></span>
                     }
 
-                    {it.agreements.active[0].metering_notification.start_time > 0 &&
+                    {it.agreements.active.length > 0 && it.agreements.active[0].metering_notification.start_time > 0 &&
                       <div>
                         <br />
                         <List.Description><strong>Metering Information</strong></List.Description>


### PR DESCRIPTION
…k for oboject existence

This should fix the location service not being registered even though other services are.