### PR TITLE
Bug/reg nodeurl dashboardstale

### DIFF
--- a/src/components/Dashboard/presenter.js
+++ b/src/components/Dashboard/presenter.js
@@ -206,7 +206,7 @@ class Dashboard extends Component {
             <Segment key={it.sensor_urls.join('/')}>
 
               {'agreements' in it ?
-                <Header size="medium">{it.agreements.active.length > 0 ? it.agreements.active[0].workload_to_run.url : it.label} <small>v{it.agreements.active[0].workload_to_run.version} by {it.agreements.active[0].workload_to_run.org}</small></Header>
+                <Header size="medium">{it.agreements.active.length > 0 ? it.agreements.active[0].workload_to_run.url : it.label} <small>{it.agreements.active.length > 0 && `${it.agreements.active[0].workload_to_run.version} by ${it.agreements.active[0].workload_to_run.org}`}</small></Header>
                 :
                 <Header size="medium">{it.label}</Header>
               }

--- a/src/components/PatternView/presenter.js
+++ b/src/components/PatternView/presenter.js
@@ -137,26 +137,36 @@ class PatternView extends Component {
                       .then((res) => {
                         onSetDeviceConfigured()
                             .then((res) => {
+                              this.stateFetching(false);
+                              this.stateSubmitting(false);
                               router.push('/dashboard');
                             })
                             .catch((err) => {
                               console.error(err);
+                              this.stateFetching(false);
+                              this.stateSubmitting(false);
                               this.showErr(err);
                             })
                       })
                       .catch((err) => {
                         console.error(err);
+                        this.stateFetching(false);
+                        this.stateSubmitting(false);
                         this.showErr(err);
                       })
                 })
                 .catch((err) => {
                   console.error(err);
+                  this.stateFetching(false);
+                  this.stateSubmitting(false);
                   this.showErr(err);
                 })
           }, 3000);
         })
         .catch(err => {
           console.error(err);
+          this.stateFetching(false);
+          this.stateSubmitting(false);
           this.showErr(err);
         })
   }

--- a/src/components/PatternView/presenter.js
+++ b/src/components/PatternView/presenter.js
@@ -127,7 +127,7 @@ class PatternView extends Component {
     } = this.props;
     this.setState({ephemeral: {submitting: true}});
     // CB hell... would prefer promise-sequential
-    accountFormDataSubmit(configuration.exchange_api, device.id, accountForm, accountForm.expectExistingAccount, this.state.selectedPattern.split('/')[1])
+    accountFormDataSubmit(configuration.exchange_api, accountForm.fields.account.deviceid, accountForm, accountForm.expectExistingAccount, this.state.selectedPattern.split('/')[1])
         .then((res) => {
           // Need to wait for account form fetch to finish
           setTimeout(() => {


### PR DESCRIPTION
* fix issue where error messes were not being displayed because the semantic ui loader would not disappear
* fix agreements in dashboard trying to render workload_to_run before existence
* fix url for node registration